### PR TITLE
rsolr 1.0.8 support

### DIFF
--- a/lib/rsolr_support.rb
+++ b/lib/rsolr_support.rb
@@ -4,15 +4,22 @@ if defined? RSolr::Client
 
   class RSolr::Client
     protected
-  
-    def map_params(params)
-      params ||= {}
-      {:wt=>:javabin}.merge(params)
+
+    def send_and_receive_with_java_bin(path, opts={})
+      if opts[:params].nil?
+        opts[:params]={}
+      end
+      opts[:params][:wt] = :javabin
+
+      send_and_receive_without_java_bin(path, opts)
     end
-  
-    def adapt_response_with_java_bin(connection_response)
-      data = adapt_response_without_java_bin(connection_response)
-      data = JavaBin.parser.new.parse(data) if data.raw[:params][:wt] == :javabin
+
+    alias_method :send_and_receive_without_java_bin, :send_and_receive
+    alias_method :send_and_receive, :send_and_receive_with_java_bin
+
+    def adapt_response_with_java_bin(request, response)
+      data = adapt_response_without_java_bin(request, response)
+      data = JavaBin.parser.new.parse(data) if request[:params][:wt] == :javabin
       data
     end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,6 +2,7 @@
 require 'rubygems'
 require 'test/unit'
 
+ENV['TZ']='JST-9'
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'java_bin'


### PR DESCRIPTION
In this pull request we have modified the gem in order to work with the new RSolr::Client.

Two modifications: rsolr_support.rb and the test helper so that we mimick japan's timezone (otherwise the test suite couldn't run).

We also propose to add the rsolr as a test dependency in order to write an integration test.

Thanks!
Moreno & Roberto from Team Iguana
