### PR TITLE
Automatic build and 1.8.7 fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: ruby
 rvm:
   - 1.9.3
   - 1.9.2
+  - 1.8.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
-
+language: ruby
+rvm:
+  - 1.9.3
+  - 1.9.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,1 @@
-before_script:
-  - "cd ext/java_bin/ext/; ruby extconf.rb; make; cd ../../.."
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'jeweler'
+gem 'rake-compiler'
 gem 'json'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,8 @@ GEM
     mocha (0.12.3)
       metaclass (~> 0.0.1)
     rake (0.9.2.2)
+    rake-compiler (0.8.1)
+      rake
     rdoc (3.12)
       json (~> 1.4)
     rsolr (1.0.8)
@@ -25,4 +27,5 @@ DEPENDENCIES
   jeweler
   json
   mocha
+  rake-compiler
   rsolr

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,13 @@
 require 'rubygems'
 require 'rake'
+require 'rake/extensiontask'
+
+Rake::ExtensionTask.new do |ext|
+  ext.name = 'parser'                # indicate the name of the extension.
+  ext.ext_dir = 'ext/java_bin/ext'         # search for 'hello_world' inside it.
+  ext.lib_dir = 'lib/java_bin/ext'              # put binaries into this folder.
+  ext.tmp_dir = 'tmp'                     # temporary folder used during compilation.
+end
 
 begin
   require 'jeweler'
@@ -38,7 +46,7 @@ rescue LoadError
   end
 end
 
-task :test
+task :test => :compile
 
 task :default => :test
 

--- a/test/test_rsolr_support.rb
+++ b/test/test_rsolr_support.rb
@@ -1,4 +1,4 @@
-require_relative 'helper'
+require 'helper'
 
 class TestRSolrSupportTest < Test::Unit::TestCase
   def test_queries_are_performed_with_javabin

--- a/test/test_rsolr_support.rb
+++ b/test/test_rsolr_support.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require File.dirname(__FILE__) + '/helper'
 
 class TestRSolrSupportTest < Test::Unit::TestCase
   def test_queries_are_performed_with_javabin
@@ -7,6 +7,7 @@ class TestRSolrSupportTest < Test::Unit::TestCase
     rsolr_connection.expects(:execute).
             with { |rsolr_client, params|
               assert_equal({:wt => :javabin}, params[:params])
+              true
             }.
             returns(:status => 200,
                     :headers => '',

--- a/test/test_rsolr_support.rb
+++ b/test/test_rsolr_support.rb
@@ -6,7 +6,7 @@ class TestRSolrSupportTest < Test::Unit::TestCase
     rsolr_connection=mock()
     rsolr_connection.expects(:execute).
             with { |rsolr_client, params|
-              assert_equal({wt: :javabin}, params[:params])
+              assert_equal({:wt => :javabin}, params[:params])
             }.
             returns(:status => 200,
                     :headers => '',


### PR DESCRIPTION
Hi,

in this pull request you'll find:
- automatic build thanks to rake-compiler, in this way there is not need for special scripts before development
- 1.8.7 fix: in the previous pull we broke 1.8.7 support. In addition, we added travis instructions to check the build aganinst the most common rubies.

Thanks!
Moreno
